### PR TITLE
More iterations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ On the actual build box `launchd` writes standard output in
 The config file must be a JSON file under `dashboard_box` and define the
 following variables:
 
- * `ANDROID_DEVICE_ID` - the ID of the Android device used for performance
+ * `android_device_id` - the ID of the Android device used for performance
    testing
- * `FIREBASE_FLUTTER_DASHBOARD_TOKEN` - authentication token to Firebase used to
+ * `firebase_flutter_dashboard_token` - authentication token to Firebase used to
    upload metrics (not needed for local testing)
 
 Example:
 
 ```json
 {
-  "ANDROID_DEVICE_ID": "...",
-  "FIREBASE_FLUTTER_DASHBOARD_TOKEN": "..."
+  "android_device_id": "...",
+  "firebase_flutter_dashboard_token": "..."
 }
 ```
 

--- a/bin/build.dart
+++ b/bin/build.dart
@@ -3,19 +3,19 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:intl/intl.dart';
 import 'package:path/path.dart' as path;
 import 'package:stack_trace/stack_trace.dart';
 
+import 'package:dashboard_box/src/analysis.dart';
 import 'package:dashboard_box/src/utils.dart';
 import 'package:dashboard_box/src/firebase_uploader.dart';
 
 Future<Null> main(List<String> args) async {
   if (args.length != 1)
-    fail('Expects a single argument pointing to the root directory of the dashboard but got: ${args}');
+    fail('Expects a single argument pointing to the root directory of the dashboard but got: $args');
 
   config = new Config(path.normalize(path.absolute(args.single)));
 
@@ -104,7 +104,7 @@ Future<int> runTest(String testDirectory, String testTarget, String testName) {
       '-d',
       config.androidDeviceId
     ]);
-    copy(file('${testDirectory}/build/${testName}.timeline_summary.json'),
+    copy(file('$testDirectory/build/${testName}.timeline_summary.json'),
         config.dataDirectory, name: '${testName}__timeline_summary.json');
   });
 }
@@ -119,101 +119,9 @@ Future<int> runStartupTest(String testDirectory, String testName) {
       '-d',
       config.androidDeviceId
     ]);
-    copy(file('${testDirectory}/build/start_up_info.json'),
+    copy(file('$testDirectory/build/start_up_info.json'),
         config.dataDirectory, name: '${testName}__start_up.json');
   });
-}
-
-Future<Null> runAnalyzerTests() async {
-  DateTime now = new DateTime.now();
-  String sdk = await getDartVersion();
-  String commit = await getFlutterRepoCommit();
-
-  Benchmark benchmark = new FlutterAnalyzeBenchmark(now, sdk, commit);
-  section(benchmark.name);
-  await runBenchmark(benchmark, iterations: 3);
-
-  benchmark = new FlutterAnalyzeAppBenchmark(now, sdk, commit);
-  section(benchmark.name);
-  await runBenchmark(benchmark, iterations: 3);
-}
-
-class FlutterAnalyzeBenchmark extends Benchmark {
-  FlutterAnalyzeBenchmark(this.time, this.sdk, this.commit) : super('flutter analyze --flutter-repo');
-
-  final DateTime time;
-  final String sdk;
-  final String commit;
-
-  File get benchmarkFile => file(path.join(config.flutterDirectory.path, 'analysis_benchmark.json'));
-
-  @override
-  Future<num> run() async {
-    rm(benchmarkFile);
-    await inDirectory(config.flutterDirectory, () async {
-      await flutter('analyze', options: ['--flutter-repo', '--benchmark']);
-    });
-    return _patchupAnalysisResult(benchmarkFile, time, expected: 25.0, sdk: sdk, commit: commit);
-  }
-
-  @override
-  void markLastRunWasBest(num result) {
-    copy(benchmarkFile, config.dataDirectory, name: 'analyzer_cli__analysis_time.json');
-  }
-}
-
-class FlutterAnalyzeAppBenchmark extends Benchmark {
-  FlutterAnalyzeAppBenchmark(this.time, this.sdk, this.commit) : super('analysis server mega_gallery');
-
-  final DateTime time;
-  final String sdk;
-  final String commit;
-
-  Directory get megaDir => dir(path.join(config.flutterDirectory.path, 'dev/benchmarks/mega_gallery'));
-  File get benchmarkFile => file(path.join(megaDir.path, 'analysis_benchmark.json'));
-
-  Future<Null> init() {
-    return inDirectory(config.flutterDirectory, () async {
-      await dart(['dev/tools/mega_gallery.dart']);
-    });
-  }
-
-  @override
-  Future<num> run() async {
-    rm(benchmarkFile);
-    await inDirectory(megaDir, () async {
-      await flutter('analyze', options: ['--watch', '--benchmark']);
-    });
-    return _patchupAnalysisResult(benchmarkFile, time, expected: 20.0, sdk: sdk, commit: commit);
-  }
-
-  @override
-  void markLastRunWasBest(num result) {
-    copy(benchmarkFile, config.dataDirectory, name: 'analyzer_server__analysis_time.json');
-  }
-}
-
-num _patchupAnalysisResult(File jsonFile, DateTime now, {
-  double expected,
-  String sdk,
-  String commit
-}) {
-  Map<String, dynamic> json;
-  if (jsonFile.existsSync())
-    json = JSON.decode(jsonFile.readAsStringSync());
-  else
-    json = <String, dynamic>{};
-
-  json['timestamp'] = now.millisecondsSinceEpoch;
-  if (expected != null)
-    json['expected'] = expected;
-  if (sdk != null)
-    json['sdk'] = sdk;
-  if (commit != null)
-    json['commit'] = expected;
-  jsonFile.writeAsStringSync(jsonEncode(json));
-
-  return json['time'];
 }
 
 Future<Null> generateBuildInfo() async {
@@ -230,39 +138,4 @@ Future<Null> uploadDataToFirebase() async {
   for (File file in ls(config.dataDirectory)) {
     await uploadToFirebase(file);
   }
-}
-
-abstract class Benchmark {
-  Benchmark(this.name);
-
-  final String name;
-
-  Future<Null> init() => new Future.value();
-
-  Future<num> run();
-
-  void markLastRunWasBest(num result);
-
-  String toString() => name;
-}
-
-Future<num> runBenchmark(Benchmark benchmark, { int iterations: 1 }) async {
-  await benchmark.init();
-
-  num minValue;
-
-  while (iterations > 0) {
-    iterations--;
-
-    print('');
-
-    num result = await benchmark.run();
-
-    if (minValue == null || result < minValue) {
-      benchmark.markLastRunWasBest(result);
-      minValue = result;
-    }
-  }
-
-  return minValue;
 }

--- a/bin/build.dart
+++ b/bin/build.dart
@@ -16,7 +16,7 @@ Future<Null> main(List<String> args) async {
   if (args.length != 1)
     fail('Expects a single argument pointing to the root directory of the dashboard but got: ${args}');
 
-  config = new Config(args.single);
+  config = new Config(path.normalize(path.absolute(args.single)));
 
   Chain.capture(() async {
     section('Build started on ${new DateTime.now()}');
@@ -30,6 +30,10 @@ Future<Null> main(List<String> args) async {
     await build();
 
     section('Build finished on ${new DateTime.now()}');
+  }, onError: (error, Chain chain) {
+    print(error);
+    print(chain.terse);
+    exit(1);
   });
 }
 
@@ -63,7 +67,11 @@ Future<Null> getFlutter() async {
 
   await exec('git', ['clone', '--depth', '1', 'https://github.com/flutter/flutter.git']);
   await flutter('config', options: ['--no-analytics']);
+
+  section('flutter doctor');
   await flutter('doctor');
+
+  section('flutter update-packages');
   await flutter('update-packages');
 }
 
@@ -115,32 +123,77 @@ Future<int> runStartupTest(String testDirectory, String testName) {
 Future<Null> runAnalyzerTests() async {
   DateTime now = new DateTime.now();
   String sdk = await getDartVersion();
+  String commit = await getFlutterRepoCommit();
 
-  section('flutter analyze --flutter-repo');
-  File benchmark = file(path.join(config.flutterDirectory.path, 'analysis_benchmark.json'));
-  rm(benchmark);
-  await inDirectory(config.flutterDirectory, () async {
-    await flutter('analyze', options: ['--flutter-repo', '--benchmark']);
-  });
+  Benchmark benchmark = new FlutterAnalyzeBenchmark(now, sdk, commit);
+  section(benchmark.name);
+  await runBenchmark(benchmark, iterations: 3);
 
-  _patchupAnalysisResult(benchmark, now, expected: 25.0, sdk: sdk);
-  copy(benchmark, config.dataDirectory, name: 'analyzer_cli__analysis_time.json');
-
-  section('analysis server mega_gallery');
-  Directory megaDir = dir(path.join(config.flutterDirectory.path, 'dev/benchmarks/mega_gallery'));
-  benchmark = file(path.join(megaDir.path, 'analysis_benchmark.json'));
-  rm(benchmark);
-  await inDirectory(config.flutterDirectory, () async {
-    await dart(['dev/tools/mega_gallery.dart']);
-  });
-  await inDirectory(megaDir, () async {
-    await flutter('analyze', options: ['--watch', '--benchmark']);
-  });
-  _patchupAnalysisResult(benchmark, now, expected: 10.0, sdk: sdk);
-  copy(benchmark, config.dataDirectory, name: 'analyzer_server__analysis_time.json');
+  benchmark = new FlutterAnalyzeAppBenchmark(now, sdk, commit);
+  section(benchmark.name);
+  await runBenchmark(benchmark, iterations: 3);
 }
 
-void _patchupAnalysisResult(File jsonFile, DateTime now, { double expected, String sdk}) {
+class FlutterAnalyzeBenchmark extends Benchmark {
+  FlutterAnalyzeBenchmark(this.time, this.sdk, this.commit) : super('flutter analyze --flutter-repo');
+
+  final DateTime time;
+  final String sdk;
+  final String commit;
+
+  File get benchmarkFile => file(path.join(config.flutterDirectory.path, 'analysis_benchmark.json'));
+
+  @override
+  Future<num> run() async {
+    rm(benchmarkFile);
+    await inDirectory(config.flutterDirectory, () async {
+      await flutter('analyze', options: ['--flutter-repo', '--benchmark']);
+    });
+    return _patchupAnalysisResult(benchmarkFile, time, expected: 25.0, sdk: sdk, commit: commit);
+  }
+
+  @override
+  void markLastRunWasBest(num result) {
+    copy(benchmarkFile, config.dataDirectory, name: 'analyzer_cli__analysis_time.json');
+  }
+}
+
+class FlutterAnalyzeAppBenchmark extends Benchmark {
+  FlutterAnalyzeAppBenchmark(this.time, this.sdk, this.commit) : super('analysis server mega_gallery');
+
+  final DateTime time;
+  final String sdk;
+  final String commit;
+
+  Directory get megaDir => dir(path.join(config.flutterDirectory.path, 'dev/benchmarks/mega_gallery'));
+  File get benchmarkFile => file(path.join(megaDir.path, 'analysis_benchmark.json'));
+
+  Future<Null> init() {
+    return inDirectory(config.flutterDirectory, () async {
+      await dart(['dev/tools/mega_gallery.dart']);
+    });
+  }
+
+  @override
+  Future<num> run() async {
+    rm(benchmarkFile);
+    await inDirectory(megaDir, () async {
+      await flutter('analyze', options: ['--watch', '--benchmark']);
+    });
+    return _patchupAnalysisResult(benchmarkFile, time, expected: 20.0, sdk: sdk, commit: commit);
+  }
+
+  @override
+  void markLastRunWasBest(num result) {
+    copy(benchmarkFile, config.dataDirectory, name: 'analyzer_server__analysis_time.json');
+  }
+}
+
+num _patchupAnalysisResult(File jsonFile, DateTime now, {
+  double expected,
+  String sdk,
+  String commit
+}) {
   Map<String, dynamic> json;
   if (jsonFile.existsSync())
     json = JSON.decode(jsonFile.readAsStringSync());
@@ -148,11 +201,15 @@ void _patchupAnalysisResult(File jsonFile, DateTime now, { double expected, Stri
     json = <String, dynamic>{};
 
   json['timestamp'] = now.millisecondsSinceEpoch;
-  if (sdk != null)
-    json['sdk'] = sdk;
   if (expected != null)
     json['expected'] = expected;
+  if (sdk != null)
+    json['sdk'] = sdk;
+  if (commit != null)
+    json['commit'] = expected;
   jsonFile.writeAsStringSync(jsonEncode(json));
+
+  return json['time'];
 }
 
 Future<Null> generateBuildInfo() async {
@@ -169,4 +226,39 @@ Future<Null> uploadDataToFirebase() async {
   for (File file in ls(config.dataDirectory)) {
     await uploadToFirebase(file);
   }
+}
+
+abstract class Benchmark {
+  Benchmark(this.name);
+
+  final String name;
+
+  Future<Null> init() => new Future.value();
+
+  Future<num> run();
+
+  void markLastRunWasBest(num result);
+
+  String toString() => name;
+}
+
+Future<num> runBenchmark(Benchmark benchmark, { int iterations: 1 }) async {
+  await benchmark.init();
+
+  num minValue;
+
+  while (iterations > 0) {
+    iterations--;
+
+    print('');
+
+    num result = await benchmark.run();
+
+    if (minValue == null || result < minValue) {
+      benchmark.markLastRunWasBest(result);
+      minValue = result;
+    }
+  }
+
+  return minValue;
 }

--- a/lib/src/analysis.dart
+++ b/lib/src/analysis.dart
@@ -1,0 +1,104 @@
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+
+import 'benchmarks.dart';
+import 'utils.dart';
+
+Future<Null> runAnalyzerTests() async {
+  DateTime now = new DateTime.now();
+  String sdk = await getDartVersion();
+  String commit = await getFlutterRepoCommit();
+
+  Benchmark benchmark = new FlutterAnalyzeBenchmark(now, sdk, commit);
+  section(benchmark.name);
+  await runBenchmark(benchmark, iterations: 3);
+
+  benchmark = new FlutterAnalyzeAppBenchmark(now, sdk, commit);
+  section(benchmark.name);
+  await runBenchmark(benchmark, iterations: 3);
+}
+
+class FlutterAnalyzeBenchmark extends Benchmark {
+  FlutterAnalyzeBenchmark(this.time, this.sdk, this.commit) : super('flutter analyze --flutter-repo');
+
+  final DateTime time;
+  final String sdk;
+  final String commit;
+
+  File get benchmarkFile => file(path.join(config.flutterDirectory.path, 'analysis_benchmark.json'));
+
+  @override
+  Future<num> run() async {
+    rm(benchmarkFile);
+    await inDirectory(config.flutterDirectory, () async {
+      await flutter('analyze', options: ['--flutter-repo', '--benchmark']);
+    });
+    return _patchupResult(benchmarkFile, time, expected: 25.0, sdk: sdk, commit: commit);
+  }
+
+  @override
+  void markLastRunWasBest(num result, List<num> allRuns) {
+    copy(benchmarkFile, config.dataDirectory, name: 'analyzer_cli__analysis_time.json');
+  }
+}
+
+class FlutterAnalyzeAppBenchmark extends Benchmark {
+  FlutterAnalyzeAppBenchmark(this.time, this.sdk, this.commit) : super('analysis server mega_gallery');
+
+  final DateTime time;
+  final String sdk;
+  final String commit;
+
+  Directory get megaDir => dir(path.join(config.flutterDirectory.path, 'dev/benchmarks/mega_gallery'));
+  File get benchmarkFile => file(path.join(megaDir.path, 'analysis_benchmark.json'));
+
+  Future<Null> init() {
+    return inDirectory(config.flutterDirectory, () async {
+      await dart(['dev/tools/mega_gallery.dart']);
+    });
+  }
+
+  @override
+  Future<num> run() async {
+    rm(benchmarkFile);
+    await inDirectory(megaDir, () async {
+      await flutter('analyze', options: ['--watch', '--benchmark']);
+    });
+    return _patchupResult(benchmarkFile, time, expected: 20.0, sdk: sdk, commit: commit);
+  }
+
+  @override
+  void markLastRunWasBest(num result, List<num> allRuns) {
+    copy(benchmarkFile, config.dataDirectory, name: 'analyzer_server__analysis_time.json');
+  }
+}
+
+num _patchupResult(File jsonFile, DateTime now, {
+  double expected,
+  String sdk,
+  String commit
+}) {
+  Map<String, dynamic> json;
+  if (jsonFile.existsSync())
+    json = JSON.decode(jsonFile.readAsStringSync());
+  else
+    json = <String, dynamic>{};
+
+  json['timestamp'] = now.millisecondsSinceEpoch;
+  if (expected != null)
+    json['expected'] = expected;
+  if (sdk != null)
+    json['sdk'] = sdk;
+  if (commit != null)
+    json['commit'] = expected;
+  jsonFile.writeAsStringSync(jsonEncode(json));
+
+  return json['time'];
+}

--- a/lib/src/benchmarks.dart
+++ b/lib/src/benchmarks.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+abstract class Benchmark {
+  Benchmark(this.name);
+
+  final String name;
+
+  Future<Null> init() => new Future.value();
+
+  Future<num> run();
+
+  void markLastRunWasBest(num result, List<num> allRuns);
+
+  String toString() => name;
+}
+
+Future<num> runBenchmark(Benchmark benchmark, { int iterations: 1 }) async {
+  await benchmark.init();
+
+  List<num> allRuns = <num>[];
+
+  num minValue;
+
+  while (iterations > 0) {
+    iterations--;
+
+    print('');
+
+    num result = await benchmark.run();
+
+    allRuns.add(result);
+
+    if (minValue == null || result < minValue) {
+      benchmark.markLastRunWasBest(result, allRuns);
+      minValue = result;
+    }
+  }
+
+  return minValue;
+}

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -62,18 +62,32 @@ void section(String title) {
 }
 
 Future<String> getDartVersion() async {
-  String version = await eval(dartBin, ['--version']);
+  // The Dart SDK return the version text to stderr.
+  ProcessResult result = Process.runSync('dart', ['--version']);
+  String version = result.stderr.trim();
   if (version.indexOf('(') != -1)
     version = version.substring(0, version.indexOf('(')).trim();
   return version.replaceAll('"', "'");
+}
+
+Future<String> getFlutterRepoCommit() {
+  return inDirectory(config.flutterDirectory, () {
+    return eval('git', ['rev-parse', 'HEAD']);
+  });
 }
 
 /// Executes a command and returns its exit code.
 Future<int> exec(String executable, List<String> arguments, {Map<String, String> env, bool canFail: false}) async {
   print('Executing: $executable ${arguments.join(' ')}');
   Process proc = await Process.start(executable, arguments, environment: env, workingDirectory: cwd);
-  stdout.addStream(proc.stdout);
-  stderr.addStream(proc.stderr);
+  proc.stdout
+    .transform(UTF8.decoder)
+    .transform(const LineSplitter())
+    .listen(print);
+  proc.stderr
+    .transform(UTF8.decoder)
+    .transform(const LineSplitter())
+    .listen(stderr.writeln);
   int exitCode = await proc.exitCode;
 
   if (exitCode != 0 && !canFail)
@@ -93,7 +107,7 @@ Future<String> eval(String executable, List<String> arguments, {Map<String, Stri
   if (exitCode != 0 && !canFail)
     fail('Executable failed with exit code ${exitCode}.');
 
-  return output;
+  return output.trimRight();
 }
 
 Future<int> flutter(String command, {List<String> options: const<String>[]}) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -63,7 +63,7 @@ void section(String title) {
 
 Future<String> getDartVersion() async {
   // The Dart SDK return the version text to stderr.
-  ProcessResult result = Process.runSync('dart', ['--version']);
+  ProcessResult result = Process.runSync(dartBin, ['--version']);
   String version = result.stderr.trim();
   if (version.indexOf('(') != -1)
     version = version.substring(0, version.indexOf('(')).trim();

--- a/web/firebase.js
+++ b/web/firebase.js
@@ -85,7 +85,7 @@
 
       clone.querySelector('.metric-number').textContent = parseFloat(data.time).toFixed(1);
       clone.querySelector('.metric-name').textContent = title;
-      clone.querySelector('.metric-target').textContent = data.expected;
+      clone.querySelector('.metric-target').textContent = data.expected.toFixed(1);
       document.querySelector('#container').appendChild(clone);
     },
 


### PR DESCRIPTION
- run more iterations of the analyzer benchmarks (run 3 iterations and take the best time of the three)
- shorter stack traces when exceptions are thrown through main()
- push the current flutter commit up to firebase w/ the rest of the data
- fix an issue w/ getting the dart sdk version
- fix an exception that occurred with piping streams:
```
Bad state: StreamSink is already bound to a stream
dart:io/io_sink.dart 159                                      _StreamSinkImpl.addStream
dart:io/stdio.dart 265                                        _StdSink.addStream
package:dashboard_box/src/utils.dart 83:10                    exec.<async>
```

@yjbanov @sethladd 