### PR TITLE
use the commit time

### DIFF
--- a/lib/src/analysis.dart
+++ b/lib/src/analysis.dart
@@ -12,15 +12,15 @@ import 'benchmarks.dart';
 import 'utils.dart';
 
 Future<Null> runAnalyzerTests() async {
-  DateTime now = new DateTime.now();
   String sdk = await getDartVersion();
   String commit = await getFlutterRepoCommit();
+  DateTime time = await getFlutterRepoCommitTimestamp(commit);
 
-  Benchmark benchmark = new FlutterAnalyzeBenchmark(now, sdk, commit);
+  Benchmark benchmark = new FlutterAnalyzeBenchmark(time, sdk, commit);
   section(benchmark.name);
   await runBenchmark(benchmark, iterations: 3);
 
-  benchmark = new FlutterAnalyzeAppBenchmark(now, sdk, commit);
+  benchmark = new FlutterAnalyzeAppBenchmark(time, sdk, commit);
   section(benchmark.name);
   await runBenchmark(benchmark, iterations: 3);
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -76,6 +76,15 @@ Future<String> getFlutterRepoCommit() {
   });
 }
 
+Future<DateTime> getFlutterRepoCommitTimestamp(String commit) {
+  // git show -s --format=%at 4b546df7f0b3858aaaa56c4079e5be1ba91fbb65
+  return inDirectory(config.flutterDirectory, () async {
+    String unixTimestamp = await eval('git', ['show', '-s', '--format=%at', commit]);
+    int secondsSinceEpoch = int.parse(unixTimestamp);
+    return new DateTime.fromMillisecondsSinceEpoch(secondsSinceEpoch * 1000);
+  });
+}
+
 /// Executes a command and returns its exit code.
 Future<int> exec(String executable, List<String> arguments, {Map<String, String> env, bool canFail: false}) async {
   print('Executing: $executable ${arguments.join(' ')}');


### PR DESCRIPTION
When uploading benchmark data, use the time associated with the flutter git commit, not the time that the benchmark was run.

@yjbanov 