### PR TITLE
flash dashboard when build is broken

### DIFF
--- a/web/buildbot.js
+++ b/web/buildbot.js
@@ -4,7 +4,7 @@
   function getBuildStatus(builderName) {
     var urlWithBuilder = url + builderName + '/';
 
-    fetch(urlWithBuilder+'builds').then(function(response){
+    fetch(urlWithBuilder + 'builds').then(function(response){
       if (response.status !== 200) {
         console.error('Error status listing builds: ' + response.status);
         return Promise.reject(new Error(response.statusText));
@@ -16,7 +16,7 @@
       var latest = keys[keys.length-1];
       return Promise.resolve(latest);
     }).then(function(latestBuildNum) {
-      return Promise.resolve(fetch(urlWithBuilder+'builds/'+latestBuildNum));
+      return Promise.resolve(fetch(urlWithBuilder + 'builds/' + latestBuildNum));
     }).then(function(response) {
       if (response.status !== 200) {
         console.error('Error status retrieving build info: ' + response.status);
@@ -30,9 +30,11 @@
       if (isSuccessful) {
         elem.classList.remove('buildbot-sad');
         elem.classList.add('buildbot-happy');
+        document.body.classList.remove('build-broken');
       } else {
         elem.classList.remove('buildbot-happy');
         elem.classList.add('buildbot-sad');
+        document.body.classList.add('build-broken');
       }
     }).catch(function(err) {
       console.error(err);

--- a/web/styles.css
+++ b/web/styles.css
@@ -13,6 +13,24 @@ body {
   padding: 10px 10px 38px 10px;
 }
 
+body.build-broken {
+  animation-name: flash-broken-build;
+  animation-duration: 4s;
+  animation-iteration-count: infinite;
+}
+
+@keyframes flash-broken-build {
+  0%   {
+    background-color: #eee;
+  }
+  50%  {
+    background-color: #ff8566;
+  }
+  100% {
+    background-color: #eee;
+  }
+}
+
 #container {
   display: flex;
   flex-flow: row wrap;
@@ -181,5 +199,20 @@ td.stats-value {
 }
 
 .buildbot-sad {
-  color: #F44336;
+  fill: #F44336;
+  animation-name: buildstatus-crazy;
+  animation-duration: 4s;
+  animation-iteration-count: infinite;
+}
+
+@keyframes buildstatus-crazy {
+  0% {
+    transform: rotateZ(-30deg) scale(1);
+  }
+  50% {
+    transform: rotateZ(30deg) scale(1.5);
+  }
+  100% {
+    transform: rotateZ(-30deg) scale(1);
+  }
 }


### PR DESCRIPTION
The background will flash continuously but not too annoyingly, and the build status icons will do a little dance.

<img width="701" alt="screen shot 2016-05-12 at 10 35 16 am" src="https://cloud.githubusercontent.com/assets/211513/15224305/7d2833b8-182d-11e6-906f-6c068580eb15.png">

/cc @sethladd @Hixie 