### PR TITLE
fix gallery JSON format; reenable the benchmark

### DIFF
--- a/bin/build.dart
+++ b/bin/build.dart
@@ -12,7 +12,7 @@ import 'package:stack_trace/stack_trace.dart';
 import 'package:dashboard_box/src/analysis.dart';
 import 'package:dashboard_box/src/buildbot.dart';
 import 'package:dashboard_box/src/firebase.dart';
-//import 'package:dashboard_box/src/gallery.dart';
+import 'package:dashboard_box/src/gallery.dart';
 import 'package:dashboard_box/src/refresh.dart';
 import 'package:dashboard_box/src/utils.dart';
 
@@ -61,7 +61,7 @@ Future<Null> build() async {
 
   await runPerfTests();
   await runStartupTests();
-  // await runGalleryTests();
+  await runGalleryTests();
   await runAnalyzerTests(sdk: sdk, commit: commit, timestamp: timestamp);
   await runRefreshTests(sdk: sdk, commit: commit, timestamp: timestamp);
 

--- a/lib/src/gallery.dart
+++ b/lib/src/gallery.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'utils.dart';
@@ -22,6 +23,15 @@ Future<Null> runGalleryTests() async {
     ]);
   });
 
-  copy(file('${galleryDirectory.path}/build/transition_durations.timeline.json'), config.dataDirectory,
-    name: 'flutter_gallery__transtition_perf.json');
+  // Route paths contains slashes, which Firebase doesn't accept in keys, so we
+  // remove them.
+  Map<String, dynamic> original = JSON.decode(file('${galleryDirectory.path}/build/transition_durations.timeline.json').readAsStringSync());
+  Map<String, dynamic> clean = new Map.fromIterable(
+    original.keys,
+    key: (String key) => key.replaceAll('/', ''),
+    value: (String key) => original[key]
+  );
+
+  file('${config.dataDirectory.path}/flutter_gallery__transtition_perf.json')
+    .writeAsStringSync(JSON.encode(clean));
 }


### PR DESCRIPTION
Firebase doesn't like the slashes in front of the key names. Gallery uses route names as benchmark keys, which contain slashes. So this change removes them.

/cc @devoncarew @sethladd 