### PR TITLE
switch from --profile to --debug

### DIFF
--- a/bin/build.dart
+++ b/bin/build.dart
@@ -118,7 +118,8 @@ Future<int> runTest(String testDirectory, String testTarget, String testName) {
     await pub('get');
     await flutter('drive', options: [
       '--verbose',
-      '--profile',
+      // TODO(yjbanov): switch to --profile when ready (http://dartbug.com/26550)
+      '--debug',
       '--trace-startup', // Enables "endless" timeline event buffering.
       '-t',
       testTarget,
@@ -135,7 +136,8 @@ Future<int> runStartupTest(String testDirectory, String testName) {
     await pub('get');
     await flutter('run', options: [
       '--verbose',
-      '--profile',
+      // TODO(yjbanov): switch to --profile when ready (http://dartbug.com/26550)
+      '--debug',
       '--trace-startup',
       '-d',
       config.androidDeviceId

--- a/lib/src/gallery.dart
+++ b/lib/src/gallery.dart
@@ -14,7 +14,8 @@ Future<Null> runGalleryTests() async {
     await pub('get');
     await flutter('drive', options: [
       '--verbose',
-      '--profile',
+      // TODO(yjbanov): switch to --profile when ready (http://dartbug.com/26550)
+      '--debug',
       '--trace-startup',
       '-t',
       'test_driver/transitions_perf.dart',


### PR DESCRIPTION
Due to http://dartbug.com/26550 we cannot use `--profile` atm and we no longer have `--no-checked`. Let's use `--debug` to avoid bitrot.

/cc @devoncarew 