### PR TITLE
reset build logs

### DIFF
--- a/job.plist
+++ b/job.plist
@@ -30,9 +30,8 @@
     <integer>1200</integer>
 
     <key>StandardOutPath</key>
-    <string>/tmp/flutter.dashboard.stdout.txt</string>
-
+    <string>/tmp/flutter.dashboard.output.txt</string>
     <key>StandardErrorPath</key>
-    <string>/tmp/flutter.dashboard.stderr.txt</string>
+    <string>/tmp/flutter.dashboard.output.txt</string>
   </dict>
 </plist>

--- a/setup.sh
+++ b/setup.sh
@@ -19,6 +19,8 @@ GSUTIL=${GSUTIL:-"/Users/$USER/google-cloud-sdk/bin/gsutil"}
 
 (cd $SCRIPT_DIRECTORY; git pull)
 
+rm -f /tmp/flutter.dashboard.output.txt
+
 set +e
 (cd $ROOT_DIRECTORY; ROOT_DIRECTORY=$ROOT_DIRECTORY $SCRIPT_DIRECTORY/run.sh)
 set -e
@@ -29,5 +31,4 @@ pushd $ROOT_DIRECTORY/flutter
 SHA=$(git rev-parse HEAD)
 popd
 
-$GSUTIL cp /tmp/flutter.dashboard.stdout.txt gs://flutter-dashboard/$SHA/stdout.txt
-$GSUTIL cp /tmp/flutter.dashboard.stderr.txt gs://flutter-dashboard/$SHA/stderr.txt
+$GSUTIL cp /tmp/flutter.dashboard.output.txt gs://flutter-dashboard/$SHA/output.txt


### PR DESCRIPTION
- delete the build logs file at the start of each invocation, so we don't upload log data from prior runs
- log both stdout and stderr to the same file

@yjbanov 