### PR TITLE
kill cancelled build logs and local backups

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -176,7 +176,6 @@ class Config {
   Config.fromProperties({
     this.rootDirectory,
     this.dataDirectory,
-    this.backupDirectory,
     this.flutterDirectory,
     this.scriptsDirectory,
     this.configFile,
@@ -187,7 +186,6 @@ class Config {
 
   Config(String rootPath) : rootDirectory = dir(rootPath) {
     this.dataDirectory = dir('${rootDirectory.path}/data');
-    this.backupDirectory = dir('${rootDirectory.path}/backup');
     this.flutterDirectory = dir('${rootDirectory.path}/flutter');
     this.scriptsDirectory = dir('${rootDirectory.path}/dashboard_box');
 
@@ -210,7 +208,6 @@ See: https://github.com/flutter/dashboard_box/blob/master/README.md
 
   final Directory rootDirectory;
   Directory dataDirectory;
-  Directory backupDirectory;
   Directory flutterDirectory;
   Directory scriptsDirectory;
   File configFile;
@@ -223,7 +220,6 @@ See: https://github.com/flutter/dashboard_box/blob/master/README.md
 '''
 rootDirectory: $rootDirectory
 dataDirectory: $dataDirectory
-backupDirectory: $backupDirectory
 flutterDirectory: $flutterDirectory
 scriptsDirectory: $scriptsDirectory
 configFile: $configFile

--- a/setup.sh
+++ b/setup.sh
@@ -29,6 +29,10 @@ set -e
 
 # Upload logs to Google Cloud Storage
 
+if [ -e "$ROOT_DIRECTORY/data/build_cancelled" ]; then
+  exit 0;
+fi
+
 pushd $ROOT_DIRECTORY/flutter
 SHA=$(git rev-parse HEAD)
 popd


### PR DESCRIPTION
* Uploading logs from cancelled builds overwrites the good logs
* Local backups don't add any value since we're uploading everything to the cloud.

/cc @devoncarew 