### PR TITLE
warm up the analysis benchmark

### DIFF
--- a/bin/build.dart
+++ b/bin/build.dart
@@ -119,6 +119,9 @@ bool get shouldUploadData => Platform.environment['UPLOAD_DASHBOARD_DATA'] == 'y
 
 Future<Null> uploadDataToFirebase(BuildResult result) async {
   for (TaskResult taskResult in result.results) {
+    if (taskResult.data == null)
+      continue;
+
     Map<String, dynamic> data = new Map<String, dynamic>.from(taskResult.data.json);
 
     Map<String, dynamic> metadata = <String, dynamic>{

--- a/bin/build.dart
+++ b/bin/build.dart
@@ -119,6 +119,7 @@ bool get shouldUploadData => Platform.environment['UPLOAD_DASHBOARD_DATA'] == 'y
 
 Future<Null> uploadDataToFirebase(BuildResult result) async {
   for (TaskResult taskResult in result.results) {
+    // TODO(devoncarew): We should also upload the fact that these tasks failed.
     if (taskResult.data == null)
       continue;
 

--- a/lib/src/analysis.dart
+++ b/lib/src/analysis.dart
@@ -22,7 +22,7 @@ List<Task> createAnalyzerTests({
       (_) async {
         Benchmark benchmark = new FlutterAnalyzeBenchmark(sdk, commit, timestamp);
         section(benchmark.name);
-        await runBenchmark(benchmark, iterations: 3);
+        await runBenchmark(benchmark, iterations: 3, warmUpBenchmark: true);
         return benchmark.bestResult;
       }
     ),
@@ -31,7 +31,7 @@ List<Task> createAnalyzerTests({
       (_) async {
         Benchmark benchmark = new FlutterAnalyzeAppBenchmark(sdk, commit, timestamp);
         section(benchmark.name);
-        await runBenchmark(benchmark, iterations: 3);
+        await runBenchmark(benchmark, iterations: 3, warmUpBenchmark: true);
         return benchmark.bestResult;
       }
     ),

--- a/lib/src/benchmarks.dart
+++ b/lib/src/benchmarks.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+
 import 'framework.dart';
 
 abstract class Benchmark {
@@ -19,12 +20,18 @@ abstract class Benchmark {
   String toString() => name;
 }
 
-Future<num> runBenchmark(Benchmark benchmark, { int iterations: 1 }) async {
+Future<num> runBenchmark(Benchmark benchmark, {
+  int iterations: 1,
+  bool warmUpBenchmark: false
+}) async {
   await benchmark.init();
 
   List<num> allRuns = <num>[];
 
   num minValue;
+
+  if (warmUpBenchmark)
+    await benchmark.run();
 
   while (iterations > 0) {
     iterations--;

--- a/lib/src/refresh.dart
+++ b/lib/src/refresh.dart
@@ -50,7 +50,9 @@ class EditRefreshBenchmark extends Benchmark {
   Future<num> run() async {
     rm(benchmarkFile);
     int exitCode = await inDirectory(megaDir, () async {
-      return await flutter('run', options: ['-d', config.androidDeviceId, '--resident', '--benchmark'], canFail: true);
+      return await flutter(
+        'run', options: ['-v', '-d', config.androidDeviceId, '--resident', '--benchmark'], canFail: true
+      );
     });
     if (exitCode != 0)
       return new Future.error(exitCode);


### PR DESCRIPTION
- run the refresh benchmark with `-v`
- warm up the analysis benchmark once; throw away that result (https://github.com/flutter/flutter/issues/4262)
- fix an npe for benchmarks w/o results

@yjbanov 