### PR TITLE
link to logs; get status more frequently; do not flash whole screen

### DIFF
--- a/web/buildbot.js
+++ b/web/buildbot.js
@@ -77,29 +77,24 @@ function allBuildsGreen() {
       getBuildStatus('Mac'),
       getBuildStatus('Mac Engine')
     ]).then(function() {
-      if (allBuildsGreen()) {
-        document.body.classList.remove('build-broken');
-      } else {
-        document.body.classList.add('build-broken');
-      }
-
-      var elem = document.querySelector('#dashboard-status');
-      elem.classList.remove('buildbot-sad');
+      var dashboardStatusSpan = document.querySelector('#dashboard-status');
+      var dashboardLogLink = document.querySelector('#dashboard-log-link');
+      dashboardStatusSpan.classList.remove('buildbot-sad');
       if (allBuildsGreen()) {
         // Show dashboard status green iff it and all other builds are green.
-        elem.style.color = 'green';
+        dashboardLogLink.style.color = '#4CAF50';
       } else if (buildStatuses['dashboard'] === false) {
         // The dashboard is explicitly broken. Go into the broken build mode.
-        elem.style.color = 'red';
-        elem.classList.add('buildbot-sad');
+        dashboardLogLink.style.color = 'red';
+        dashboardStatusSpan.classList.add('buildbot-sad');
       } else {
         // If one of the buildbots is red the dashboard status is irrelevant.
         // Showing it red won't add any useful information, and showing it green
         // is misleading.
-        elem.style.color = 'gray';
+        dashboardLogLink.style.color = '#DDD';
       }
 
-      setTimeout(refreshAllBuildStatuses, 10 * 1000);
+      setTimeout(refreshAllBuildStatuses, 5 * 1000);
     }, function() {
       // Schedule a fetch even if the previous one fails, but wait a little longer
       setTimeout(refreshAllBuildStatuses, 60 * 1000);

--- a/web/firebase.js
+++ b/web/firebase.js
@@ -206,6 +206,9 @@ var whenFirebaseReady = new Promise(function(resolve, reject) {
     if (lastJobRanTime) {
       lastJobRanTime.textContent = buildData.build_timestamp;
     }
+
+    var dashboardLogLink = document.querySelector('#dashboard-log-link');
+    dashboardLogLink.href = `https://pantheon.corp.google.com/m/cloudstorage/b/flutter-dashboard/o/${ buildData.revision }/output.txt`;
   }
 
   function generateBoxes(measurements) {

--- a/web/index.html
+++ b/web/index.html
@@ -59,7 +59,7 @@
           </svg>
 
           <span title="Dashboard" id="dashboard-status">
-            &#8679;
+            <a id="dashboard-log-link" target="_blank" href="#">&#11014;</a>
           </span>
         </div>
       </div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13,12 +13,6 @@ body {
   padding: 10px 10px 38px 10px;
 }
 
-body.build-broken {
-  animation-name: flash-broken-build;
-  animation-duration: 4s;
-  animation-iteration-count: infinite;
-}
-
 @keyframes flash-broken-build {
   0%   {
     background-color: #eee;


### PR DESCRIPTION
We are color-coding and animating broken builds individually. Flashing the whole screen is excessive and the logic for when to flash it was broken anyway.