### PR TITLE
refactor golem data to use Firebase-compatible key names

### DIFF
--- a/bin/build.dart
+++ b/bin/build.dart
@@ -140,7 +140,7 @@ Future<Null> generateBuildInfoFile(String revision, BuildResult result, bool syn
 bool get shouldUploadData => Platform.environment['UPLOAD_DASHBOARD_DATA'] == 'yes';
 
 Future<Null> uploadDataToFirebase(BuildResult result) async {
-  Map<String, dynamic> golemData = <String, dynamic>{};
+  List<Map<String, dynamic>> golemData = <Map<String, dynamic>>[];
 
   for (TaskResult taskResult in result.results) {
     // TODO(devoncarew): We should also upload the fact that these tasks failed.
@@ -153,10 +153,11 @@ Future<Null> uploadDataToFirebase(BuildResult result) async {
       for (String scoreKey in taskResult.data.benchmarkScoreKeys) {
         String benchmarkName = '${taskResult.task.name}.$scoreKey';
         if (registeredBenchmarkNames.contains(benchmarkName)) {
-          golemData[benchmarkName] = <String, dynamic>{
+          golemData.add(<String, dynamic>{
+            'benchmark_name': benchmarkName,
             'golem_revision': result.golemRevision,
             'score': taskResult.data.json[scoreKey],
-          };
+          });
         }
       }
     }
@@ -172,8 +173,8 @@ Future<Null> uploadDataToFirebase(BuildResult result) async {
         .writeAsString(jsonEncode(data));
   }
 
-//  await file('${config.dataDirectory.path}/golem_data.json')
-//      .writeAsString(jsonEncode(golemData));
+  await file('${config.dataDirectory.path}/golem_data.json')
+      .writeAsString(jsonEncode(golemData));
 
   if (!shouldUploadData)
     return null;

--- a/bin/firebase_to_golem.dart
+++ b/bin/firebase_to_golem.dart
@@ -79,10 +79,11 @@ Future<Null> syncToGolem() async {
 Future<Null> sendMetrics() async {
   print('Sending metrics to golem');
 
-  Map<String, dynamic> data = await firebaseDownloadCurrent('golem_data');
-  for (String benchmarkName in data.keys) {
-    int golemRevision = data['golem_revision'];
-    num score = data['score'];
+  List<Map<String, dynamic>> golemResults = await firebaseDownloadCurrent('golem_data');
+  for (Map<String, dynamic> result in golemResults) {
+    String benchmarkName = result['benchmark_name'];
+    int golemRevision = result['golem_revision'];
+    num score = result['score'];
     _sendMetric(benchmarkName, golemRevision, score);
   }
 }

--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -49,7 +49,7 @@ Future<Null> uploadMeasurementToFirebase(String measurementKey, dynamic jsonData
   await ref.child('history').push(jsonData);
 }
 
-Future<Map<String, dynamic>> firebaseDownloadCurrent(String measurementKey) async {
+Future<dynamic> firebaseDownloadCurrent(String measurementKey) async {
   DataSnapshot snapshot = await _measurements()
       .child(measurementKey)
       .child('current')


### PR DESCRIPTION
This changes the benchmark results from a JSON object to an array with benchmark name encoded as a value rather than a key.

/cc @devoncarew 