### PR TITLE
fix type cast in Firebase lib

### DIFF
--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -58,5 +58,5 @@ Future<dynamic> firebaseDownloadCurrent(String measurementKey) async {
   if (!snapshot.exists)
     return null;
 
-  return snapshot.val as Map<String, dynamic>;
+  return snapshot.val;
 }


### PR DESCRIPTION
Firebase values can be maps as well as lists.

Will submit asap to unblock Golem syncing server.

TBR: @devoncarew 